### PR TITLE
Updates to RAC 4.2.1.

### DIFF
--- a/ReactiveCocoa.podspec
+++ b/ReactiveCocoa.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'ReactiveCocoa'
-  s.version = '4.2.0'
+  s.version = '4.2.1'
   s.summary = 'A framework for composing and transforming streams of values.'
   s.description = <<-EOS
     ReactiveCocoa (RAC) is an Objective-C framework for Functional Reactive Programming.
@@ -15,56 +15,22 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.source = {
     :git => 'https://github.com/ReactiveCocoa/ReactiveCocoa.git',
-    :tag => 'v4.2.0'
+    :tag => "v#{s.version}"
   }
   s.dependency 'Result', '~> 2.0'
   s.framework = 'Foundation'
-  s.default_subspec = 'UI'
-  s.prepare_command = "sed -i '' 's@<ReactiveCocoa/\\(.*\\)>@\"\\1\"@g' ReactiveCocoa/ReactiveCocoa.h"
+  s.private_header_files = [
+    '**/*Private.h',
+    '**/*EXTRuntimeExtensions.h',
+    '**/RACEmpty*.h'
+  ]
 
-  s.subspec 'no-arc' do |ss|
-    ss.source_files = 'ReactiveCocoa/Objective-C/RACObjCRuntime.{h,m}'
-    ss.requires_arc = false
-  end
+  s.source_files = 'ReactiveCocoa/**/*.{d,h,m,swift}'
 
-  s.subspec 'Core' do |ss|
-    ss.source_files = 'ReactiveCocoa/**/*.{d,h,m,swift}'
-    ss.exclude_files = [
-      '**/ReactiveCocoa.h',
-      'ReactiveCocoa/**/*{RACObjCRuntime,AppKit,NSControl,NSText,NSTable,UIActionSheet,UIAlertView,UIBarButtonItem,UIButton,UICollectionReusableView,UIControl,UIDatePicker,UIGestureRecognizer,UIImagePicker,UIRefreshControl,UISegmentedControl,UISlider,UIStepper,UISwitch,UITableViewCell,UITableViewHeaderFooterView,UIText,MK}*'
-    ]
-    ss.header_dir = 'ReactiveCocoa'
-    ss.private_header_files = [
-      '**/*Private.h',
-      '**/*EXTRuntimeExtensions.h',
-      '**/RACEmpty*.h'
-    ]
-    ss.dependency 'ReactiveCocoa/no-arc'
-
-    ss.watchos.exclude_files = '**/NSURLConnection*'
-    ss.watchos.pod_target_xcconfig = {'GCC_PREPROCESSOR_DEFINITIONS' => 'DTRACE_PROBES_DISABLED=1'}
-  end
-
-  s.subspec 'UI' do |ss|
-    ss.dependency 'ReactiveCocoa/Core'
-
-    ss.ios.source_files = [
-      '**/ReactiveCocoa.h',
-      'ReactiveCocoa/**/*{UIActionSheet,UIAlertView,UIBarButtonItem,UIButton,UICollectionReusableView,UIControl,UIDatePicker,UIGestureRecognizer,UIImagePicker,UIRefreshControl,UISegmentedControl,UISlider,UIStepper,UISwitch,UITableViewCell,UITableViewHeaderFooterView,UIText,MK}*'
-    ]
-    ss.ios.framework = 'UIKit'
-
-    ss.osx.source_files = [
-      '**/ReactiveCocoa.h',
-      'ReactiveCocoa/**/*{AppKit,NSControl,NSText,NSTable}*'
-    ]
-    ss.osx.framework = 'AppKit'
-
-    ss.tvos.source_files = [
-      '**/ReactiveCocoa.h',
-      'ReactiveCocoa/**/*{UIButton,UICollectionReusableView,UIControl,UIGestureRecognizer,UISegmentedControl,UITableViewCell,UITableViewHeaderFooterView,UIText}*'
-    ]
-
-    ss.watchos.source_files = '**/ReactiveCocoa.h'
-  end
+  # This is a little backwards, but it's basically easier to list the files we want to exlude
+  # the files we don't want than whitelist the ones we do. Could be room for improvement later.
+  s.ios.exclude_files = 'ReactiveCocoa/**/*{AppKit,NSControl,NSText,NSTable}*'
+  s.osx.exclude_files = 'ReactiveCocoa/**/*{UIActionSheet,UIAlertView,UIBarButtonItem,UIButton,UICollectionReusableView,UIControl,UIDatePicker,UIGestureRecognizer,UIImagePicker,UIRefreshControl,UISegmentedControl,UISlider,UIStepper,UISwitch,UITableViewCell,UITableViewHeaderFooterView,UIText,MK}*'
+  s.tvos.exclude_files = 'ReactiveCocoa/**/*{AppKit,NSControl,NSText,NSTable,UIActionSheet,UIAlertView,UIDatePicker,UIImagePicker,UIRefreshControl,UISlider,UIStepper,UISwitch,MK}*'
+  s.watchos.exclude_files = 'ReactiveCocoa/**/*{UIActionSheet,UIAlertView,UIBarButtonItem,UIButton,UICollectionReusableView,UIControl,UIDatePicker,UIGestureRecognizer,UIImagePicker,UIRefreshControl,UISegmentedControl,UISlider,UIStepper,UISwitch,UITableViewCell,UITableViewHeaderFooterView,UIText,MK,AppKit,NSControl,NSText,NSTable,NSURLConnection}*'
 end


### PR DESCRIPTION
This is a pretty big simplification in the podspec made possible by RAC dropping non-ARC-compatible files in 4.2.1 (which is why I'm skipping 4.2.0). Now, we're relying on their `ReactiveCocoa.h` header for target-specific imports.

Once merged, I'd like for someone (@chrrasmussen or @dmcrodrigues maybe?) integrate this into their projects so we can test it first, then push to CocoaPods trunk once we know it works in actual apps. There's funny business with the `sed` command we've had problems with before, where the podspec lints but doesn't actually work.

Fixes #9.
