### PR TITLE
Updated ReactiveCocoa.podspec to 4.2.2 (Swift 2.2 only)

### DIFF
--- a/ReactiveCocoa.podspec
+++ b/ReactiveCocoa.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'ReactiveCocoa'
-  s.version = '4.2.1'
+  s.version = '4.2.2-swift2.2'
   s.summary = 'A framework for composing and transforming streams of values.'
   s.description = <<-EOS
     ReactiveCocoa (RAC) is an Objective-C framework for Functional Reactive Programming.
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.source = {
     :git => 'https://github.com/ReactiveCocoa/ReactiveCocoa.git',
-    :tag => "v#{s.version}"
+    :tag => "v4.2.2"
   }
   s.dependency 'Result', '~> 2.0'
   s.framework = 'Foundation'

--- a/ReactiveCocoa.podspec
+++ b/ReactiveCocoa.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'ReactiveCocoa'
-  s.version = '4.2.2-swift2.2'
+  s.version = '4.2.2'
   s.summary = 'A framework for composing and transforming streams of values.'
   s.description = <<-EOS
     ReactiveCocoa (RAC) is an Objective-C framework for Functional Reactive Programming.
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.source = {
     :git => 'https://github.com/ReactiveCocoa/ReactiveCocoa.git',
-    :tag => "v4.2.2"
+    :tag => "v#{s.version}"
   }
   s.dependency 'Result', '~> 2.0'
   s.framework = 'Foundation'
@@ -25,6 +25,7 @@ Pod::Spec.new do |s|
     '**/RACEmpty*.h'
   ]
 
+  s.pod_target_xcconfig = { 'SWIFT_VERSION' => '2.3' }
   s.source_files = 'ReactiveCocoa/**/*.{d,h,m,swift}'
 
   # This is a little backwards, but it's basically easier to list the files we want to exlude


### PR DESCRIPTION
I successfully integrated ReactiveCocoa 4.2.2 in the following projects:
- An existing project using CocoaPods 0.39.0, Xcode 7.3.1 and Swift 2.2
- A new project using CocoaPods 1.0.1, Xcode 7.3.1 and Swift 2.2

I was unable to get it to run in Xcode 8-beta 2 and beta 3. I ran into quite a few issues:
- Had to select signing identity for each target in the Pods project (seems to be fixed in CocoaPods 1.1.0-beta1)
- Xcode 8-beta 2 builds the libraries using Swift 3 per default (which doesn't work)
- "Found an unexpected Mach-O header code: ..." error when compiling
- "dyld: Library not loaded: ..." error when running on device

I get the same errors when trying integrate the current Podspec (for ReactiveCocoa 4.2.1) in Xcode 8.

Since ReactiveCocoa 4.2.2 is intended to work with Swift 2.3, maybe we could call this version `4.2.2-swift2.2` or `4.2.2-alpha-1`. What do you think? I don't know enough about CocoaPods to make it work in Xcode 8.

The result of running `pod spec lint --allow-warnings` using CocoaPods 1.0.1, Xcode 7.3.1 and Swift 2.2:

```
 -> ReactiveCocoa (4.2.2-swift2.2)
    - WARN  | source: The version should be included in the Git tag.
    - WARN  | xcodebuild:  ReactiveCocoa/ReactiveCocoa/Swift/SignalProducer.swift:1945:69: warning: 'buffer' is deprecated: Use properties instead. 'buffer' will be removed in RAC 5.0
    - WARN  | xcodebuild:  ReactiveCocoa/ReactiveCocoa/Objective-C/RACCompoundDisposable.m:85:12: warning: unused variable 'result' [-Wunused-variable]
    - WARN  | xcodebuild:  ReactiveCocoa/ReactiveCocoa/Objective-C/RACCompoundDisposable.m:132:12: warning: unused variable 'result' [-Wunused-variable]
    - WARN  | xcodebuild:  ReactiveCocoa/ReactiveCocoa/Objective-C/RACSerialDisposable.m:63:12: warning: unused variable 'result' [-Wunused-variable]
    - WARN  | xcodebuild:  ReactiveCocoa/ReactiveCocoa/Objective-C/RACSerialDisposable.m:79:12: warning: unused variable 'result' [-Wunused-variable]

Analyzed 1 podspec.

ReactiveCocoa.podspec passed validation.
```
