### PR TITLE
ReactiveCocoa 4.2.2

### DIFF
--- a/ReactiveCocoa.podspec
+++ b/ReactiveCocoa.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'ReactiveCocoa'
-  s.version = '4.2.1'
+  s.version = '4.2.2'
   s.summary = 'A framework for composing and transforming streams of values.'
   s.description = <<-EOS
     ReactiveCocoa (RAC) is an Objective-C framework for Functional Reactive Programming.


### PR DESCRIPTION
Added a podspec for ReactiveCocoa 4.2.2. Matching current one used in the trunk of ReactiveCocoa. 
Previously suggested definition `pod_target_xcconfig` is a workaround and not required with a new version of `cocoapods 1.1.0.rc.2`.
